### PR TITLE
Prefix filename with id to preserve original sorting of pictures.

### DIFF
--- a/chrome/content/main.js
+++ b/chrome/content/main.js
@@ -91,7 +91,8 @@ Components.utils.import("resource://gre/modules/FileUtils.jsm");
 	}
 	function handle_image(res, req, pi) {
 		progress(pi, 'complete');
-		write_file(album[pi].imageurl.match(/([^\/]+)\?/)[1], res);
+		// prefix filename with id+1 (so first picture is #1) for easy sorting
+		write_file((pi + 1) + " - " + album[pi].imageurl.match(/([^\/]+)\?/)[1], res);
 		in_progress--;
 		num_done++;
 		log('Downloaded ' + num_done + ' of ' + album.length + ' images');


### PR DESCRIPTION
Problem was that using async downloading, the pictures aren't downloaded in the same order as on original album and it isn't convenient. I fixed it by prefixing the name with number starting from #1.
(this commit has been tested successfully on Firefox 16)
